### PR TITLE
contrib/k8s: add service and rc definition for khealth

### DIFF
--- a/cmd/rcscheduler/rcscheduler.go
+++ b/cmd/rcscheduler/rcscheduler.go
@@ -59,7 +59,7 @@ func main() {
 		pollCount,
 		&routines.RCScheduler{
 			Client:       client,
-			Namespace:    "default",
+			Namespace:    "khealth",
 			ReplicaCount: 3,
 		},
 	)

--- a/contrib/k8s/khealth-ns.yaml
+++ b/contrib/k8s/khealth-ns.yaml
@@ -1,0 +1,7 @@
+  kind: Namespace
+  apiVersion: v1
+  metadata:
+    name: khealth
+    labels:
+      app: khealth
+

--- a/contrib/k8s/khealth-rc.yaml
+++ b/contrib/k8s/khealth-rc.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    app: khealth
+    role: master
+  name: khealth
+spec:
+  replicas: 1
+  selector:
+    app: khealth
+    role: master
+  template:
+    metadata:
+      labels:
+        app: khealth
+        role: master
+    spec:
+      containers:
+          - image: quay.io/coreos/khealth
+            name: rcscheduler
+            metadata:
+              labels:
+                module: rcscheduler
+            command:
+              - "rcscheduler"
+            ports:
+            - containerPort: 8080
+              name: rcscheduler
+

--- a/contrib/k8s/khealth-service.yaml
+++ b/contrib/k8s/khealth-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: khealth
+  name: khealth
+spec:
+  ports:
+    - port: 8080
+      targetPort: rcscheduler
+      nodePort: 31337
+  type: NodePort
+  selector:
+    app: khealth
+    role: master
+
+


### PR DESCRIPTION
rc has a single rcscheduler pod as of now. we can add more containers and ports as we add more modules
