### PR TITLE
README: Clean up idiosyncratic indents, other fmt and typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # khealth
-=====
 
 [![Docker Image on Quay.io](https://quay.io/repository/coreos/khealth/status "Docker Image on Quay.io")](https://quay.io/repository/coreos/khealth)
 
@@ -25,50 +24,58 @@ This will create a nodeport service which exposes the following status endpoints
 
 A khealth *Module* is a single command that invokes a set of Routines and a single Collector. The Collector gathers events from the Routines and exposes metrics on its status endpoint.
 
-* **`cmd/`**:
+### Directory Layout
 
-  This is where the `Module` entrypoint programs live. Each `Module` should have exactly one `main` package in an eponymous directory beneath `cmd/`.
+#### `cmd/`
 
-* **`pkg/routines`**:
+This is where the `Module` entrypoint programs live. Each `Module` should have exactly one `main` package in an eponymous directory beneath `cmd/`.
 
-  Routines are defined in structures that implement the `RoutineHandler` interface.
-  ```go
-  type RoutineHandler interface {
-  	Init() error
-	Poll() error
-	Cleanup() error
+#### `pkg/routines/`
+
+Routines are defined in structures that implement the `RoutineHandler` interface.
+
+```go
+type RoutineHandler interface {
+  Init() error
+  Poll() error
+  Cleanup() error
   }
-  ```
-  `Init` is called, and then `Poll` in a loop. When the TTL expires, `Poll` terminates, and `Cleanup` is called. Each iteration of this cycle generates events, which are sent to the Collector via the Routine struct's `Events` channel. (More advanced configurations could very well have things other than Collectors reading from a Routine's `Events` channel. This is not "common" though.)
+```
 
-  The `NewRoutine` function takes the following arguments
-  * `client`: the kubernetes api client
-  * `pollInterval`: how often (in seconds) `Poll` is called.
-  * `podTTL`: how many seconds to loop on `Poll` before calling `Cleanup`
-  * `handler`: the `RoutineHandler` for this routine.
-  It returns a pointer a khealth `Routine` struct.
-* **`pkg/collectors`**:
+`Init` is called, and then `Poll` in a loop. When the TTL expires, `Poll` terminates, and `Cleanup` is called. Each iteration of this cycle generates events, which are sent on the Routine's `Events` channel, usually to a Collector.
 
-  ```go
-  type Collector interface {
-  	Start() error
-	Status(w http.ResponseWriter, r *http.Request)
-	Terminate() error
-  }
-  ```
-  Collectors must implement the Collector interface and make use of Routines. To wire Routines to a Collector implementation, follow this general pattern:
-  * `Start` : Call `Start` on all routines this collector uses. Then begin reading events from each routines' `Events` channel and collating current state.
-  * `Status`: Serialize current state to http response.
-  * `Terminate`: Call `SignalTerminate` on each routine. `SignalTerminate` is non-blocking, so before returning you'll want to block until each Routines' `Events` channel has emitted a `nil` value. That way, when `Terminate` returns you can be assured your Routines have all cleaned up.
+The `NewRoutine` function returns a pointer to a khealth `Routine` struct. It takes the following arguments:
 
-## Modules
-- **`cmd/rcscheduler`**
-  This module uses a single routine which schedules/unschedules pause pods via a replication controller.
+* `client`: the Kubernetes API client
+* `pollInterval`: how often (in seconds) `Poll` is called
+* `podTTL`: how many seconds to loop on `Poll` before calling `Cleanup`
+* `handler`: the `RoutineHandler` for this routine
 
-  The program exposes a single health endpoint which reports the state of the latest event.
+#### `pkg/collectors/`
+
+```go
+type Collector interface {
+  Start() error
+  Status(w http.ResponseWriter, r *http.Request)
+  Terminate() error
+}
+```
+
+Collectors must implement the Collector interface and make use of Routines. To wire Routines to a Collector implementation, follow this general pattern:
+
+* `Start` : Call `Start` on all routines this collector uses. Then begin reading events from each routines' `Events` channel and collating current state.
+* `Status`: Serialize current state to HTTP response.
+* `Terminate`: Call `SignalTerminate` on each routine. `SignalTerminate` is non-blocking, so before returning you'll want to block until each Routine's `Events` channel has emitted a `nil` value. That way, when `Terminate` returns you can be assured your Routines have all cleaned up.
+
+## Included Modules
+
+### `cmd/rcscheduler/`
+
+This module uses a single routine which schedules/unschedules pause pods via a replication controller. The program exposes a single health endpoint which reports the state of the latest event.
 
 ## Roadmap
-- More routines: We want routines that do everything! Test network latency. Write to disk. Compute fibonacci sequences.
+
+* More routines: We want routines that do everything! Test network latency. Write to disk. Compute fibonacci sequences.
 
 * Prometheus integration: Collectors expose Prometheus-compatible status endpoints and metrics, providing readymade infrastructure to aggregate statistics from a set of canary pods, designed specifically to exercise Kubernetes cluster resources.
 
@@ -76,7 +83,6 @@ A khealth *Module* is a single command that invokes a set of Routines and a sing
 
 ## Who should use this?
 
-* **Cluster administrators**: Gain insight into your Kubernetes cluster's performance.  Monitor health endpoints which report on various testing routines.
+**Cluster administrators**: Gain insight into your Kubernetes cluster's performance.  Monitor health endpoints which report on various testing routines.
 
-* **Kubernetes developers**: A convenient way to "smoke test" a cluster. Feel free to write *Modules* that exist solely to torture test a cluster and have no business running on the same cluster as production assets. And turn the replica count way up!
-
+**Kubernetes developers**: A convenient way to "smoke test" a cluster. Feel free to write *Modules* that exist solely to torture test a cluster and have no business running on the same cluster as production assets. And turn the replica count way up!


### PR DESCRIPTION
On heels of @colhom 's coreos/khealth#12
